### PR TITLE
ffmpeg.py fix key error in Engine.probe

### DIFF
--- a/src/thumbor_video_engine/engines/ffmpeg.py
+++ b/src/thumbor_video_engine/engines/ffmpeg.py
@@ -163,7 +163,8 @@ class Engine(BaseEngine):
             # Load all frames, get the sum of all frames' durations
             for frame in ImageSequence.Iterator(self.image):
                 frame.load()
-                duration_ms += frame.info['duration']
+                if hasattr(frame.info, 'duration'):
+                    duration_ms += frame.info['duration']
             self.image.seek(0)
             self.duration = Decimal(duration_ms) / Decimal(1000)
         else:


### PR DESCRIPTION
Hello,
I ran today into key error on line 166 in engines/ffmpeg.py.
It turns out that duration is not always available in Image.info and there are animated gifs out there without it.

See:
[Pillow documentation](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#gif)
and
[stack overflow](https://stackoverflow.com/questions/21791012/why-does-this-gif-seem-to-have-a-0ms-duration-how-can-i-find-the-true-duration)

Checking for the attribute fixed it and everything was working as expected.
