### PR TITLE
Remove expected warning message for format

### DIFF
--- a/src/thumbor_video_engine/filters/format.py
+++ b/src/thumbor_video_engine/filters/format.py
@@ -13,9 +13,9 @@ class Filter(BaseFilter):
 
     @filter_method(BaseFilter.String)
     def format(self, format):
-        logger.warning('Setting format to %s' % format)
+        logger.debug('Setting format to %s' % format)
         if format.lower() not in ALLOWED_FORMATS:
-            logger.debug('Format not allowed: %s' % format.lower())
+            logger.warning('Format not allowed: %s' % format.lower())
             self.context.request.format = None
         else:
             logger.debug('Format specified: %s' % format.lower())


### PR DESCRIPTION
Currently setting the format produces a warning.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/132/196487396-daba14fd-919b-4c89-aeba-c3bc73756bef.png">

I think the `warning` level would be better suited for bringing up issues (a wrong format). And the higher `debug` level can be used for mentioning the requested format.