### PR TITLE
ci: Fix python 3 tests, re-enable in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,22 +10,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.7", "3.8", "3.9", "3.10"]
-        # python-bin: ["python3"]
-        # thumbor-version: ["7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-bin: ["python3"]
+        thumbor-version: ["7"]
         include:
           - python-version: "2.7"
             python-version-desc: ""
             python-bin: "python2"
             thumbor-version: "6"
-          # - python-version: "3.7"
-          #   python-version-desc: " (python 3.7)"
-          # - python-version: "3.8"
-          #   python-version-desc: " (python 3.8)"
-          # - python-version: "3.9"
-          #   python-version-desc: " (python 3.9)"
-          # - python-version: "3.10"
-          #   python-version-desc: " (python 3.10)"
+          - python-version: "3.7"
+            python-version-desc: " (python 3.7)"
+          - python-version: "3.8"
+            python-version-desc: " (python 3.8)"
+          - python-version: "3.9"
+            python-version-desc: " (python 3.9)"
+          - python-version: "3.10"
+            python-version-desc: " (python 3.10)"
 
     runs-on: ubuntu-latest
     name: Thumbor ${{ matrix.thumbor-version }}${{ matrix.python-version-desc }}

--- a/tests/result_storages/test_s3_storage.py
+++ b/tests/result_storages/test_s3_storage.py
@@ -51,11 +51,6 @@ def s3_client(monkeypatch, mocker, config):
             yield botocore.session.get_session().create_client('s3', endpoint_url=endpoint_url)
 
     finally:
-        if asyncio is not None:
-            event_loop = asyncio.get_event_loop()
-            instances = getattr(Bucket, "_instances", None) or {}
-            for bucket in instances.values():
-                event_loop.run_until_complete(bucket._client.close())
         Bucket._instances = {}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,14 @@ deps =
     pytest-tornado
     pytest-cov
     !py27: thumbor >= 7.0.0
-    !py27: git+https://github.com/fdintino/aws.git@5274bd3f622f5546051cc0befdc953bbd05af05d#egg=tc_aws
+    !py27: git+https://github.com/fdintino/aws.git@9caa87ea2bdb88ec25d98cdae676c2e5b4be6b23#egg=tc_aws
     py27: tc_aws
     boto
     mirakuru
     py27: moto[server] <= 2.1.0
     !py27: moto[server]
+    !py27: boto3==1.21.21
+    !py27: botocore==1.24.21
 
 [testenv:coverage-report]
 skip_install = true


### PR DESCRIPTION
Uses a newer version of tc-aws with aiobotocore 2.2.0 as a dependency in tox.ini, and pins the requisite versions for its transitive boto3 and botocore dependencies.