### PR TITLE
chore: add Dependabot configuration for auto-merging and updates OPS-6196

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(ci)"
+  
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/dependabot-auto-merge-caller.yaml
+++ b/.github/workflows/dependabot-auto-merge-caller.yaml
@@ -1,0 +1,27 @@
+name: Auto-merge Dependabot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  dependabot-automerge-github-actions:
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login == 'dependabot[bot]'
+
+    permissions:
+      pull-requests: write
+      contents: write
+      issues: write
+    uses: theatlantic/workflows/.github/workflows/dependabot-automerge.yml@main
+    secrets:
+      AUTOMERGE_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
+    with:
+      allowed-ecosystems: 'github_actions'
+      allowed-update-types: 'minor,patch,major'
+      merge-method: 'squash'
+      days-to-wait: 10
+      security-fast-track: true
+      approve-only: false


### PR DESCRIPTION
This pull request introduces automated dependency management for both GitHub Actions and Python packages, and sets up an auto-merge workflow for Dependabot updates. These changes help keep dependencies up to date with minimal manual intervention and streamline the update process.

**Dependency management configuration:**

* Added a `.github/dependabot.yml` file to enable Dependabot for GitHub Actions and Python (`pip`) dependencies, scheduling checks monthly and setting commit message prefixes for clarity.

**Automation workflow:**

* Introduced a `.github/workflows/dependabot-auto-merge-caller.yaml` workflow to automatically approve and merge Dependabot pull requests for GitHub Actions updates, with configurable options for merge method, waiting period, and security fast-tracking.